### PR TITLE
Fix docker compose error message

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.3'
 
 services:
   web:


### PR DESCRIPTION
Docker compose script is not valid to run and a lower version fixes this.